### PR TITLE
Adding correct license to package-lock file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "ai-legion",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "@types/jest": "^29.5.0",
         "@types/lodash": "^4.14.191",


### PR DESCRIPTION
I'm pretty sure that I didn't actually provide this change. I think it may have been the AI while it was reviewing its codebase, but in either case, I'm taking credit for it.